### PR TITLE
update agent

### DIFF
--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="devops@domotz.com"
 
 EXPOSE 3000
 
-ADD https://portal.domotz.com/download/agent_packages/domotz-debian-x64-1.0.deb /root/
+ADD https://portal.domotz.com/download/agent_packages/domotz-debian-x64-1.0-2.5.0-2.7.5-b004-0023.deb /root/
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates iputils-ping net-tools
 
@@ -12,14 +12,15 @@ RUN printf "#!/bin/sh\necho N 2" > /sbin/runlevel \
  && chmod +x /sbin/runlevel \
  && printf "#!/bin/sh\nexit 0" > /usr/sbin/policy-rc.d \
  && chmod +x /usr/sbin/policy-rc.d \
- && dpkg -i /root/domotz-debian-*.deb \
- && rm /root/domotz-debian-*.deb \
- && rm -rf /var/lib/apt/lists/*
-
-RUN sed -i 's/raspberry/docker/g' /opt/domotz/etc/domotz.env
+ && dpkg -i /root/domotz-*.deb \
+ && rm /root/domotz-*.deb \
+ && rm -rf /var/lib/apt/lists/* \
+ && sed -i 's/raspberry/docker/g' /opt/domotz/etc/domotz.env
 
 RUN mkdir /opt/utils
 COPY runme.sh /opt/utils
+
+VOLUME ["/opt/domotz/var/log/domotz"]
 
 CMD service domotz start \
  && /opt/utils/runme.sh

--- a/amd64/README.md
+++ b/amd64/README.md
@@ -53,6 +53,7 @@ Given that the configuration of the Domotz Agent is written on a file on the loc
 In this way, even if you destroy the environment and rebuild the container, keeping the configuration files in the host will ensure that the Domotz Agent restarts with the same configuration.
 
 Alternatively, you can force the Docker Container to start always with the same MAC address (e.g. "docker run ...  --mac-address 02:42:AC:12:00:03 ..."). In this way, when the Domotz Agent restart, and you will be required to re-configure it with your account, you will not been asked to create a new entity, but you will be allowed to RESUME the configuration from the previous Domotz Agent.
+> setting the mac-address is not compatible with --network=host. using host networking uses the mac address of the host so destroying and re-creating a container on the same host should link properly.
 
 On Mac and Windows platforms the container is not able to discover devices and monitor them on the hosting network. However, you can monitor the Docker Daemon network and the other containers running on that.
 


### PR DESCRIPTION
update agent to latest, expose log directory as volume.

some notes however. you have set up the repo to be architecture based - however your existing image as well as this one is not really amd64 based but x86-64. i am not sure that you even need to focus on architecture for docker. technically there is a ubuntu docker image for amd64 if you really want and then we would have to update the deb package here.

i have tested this and it works.

i exposed the logs directory in case you want to mount that on the host for debug purposes.

your note about mounting the etc folder as a volume does not work in reality as the agent seems to depend on files initially being there. can we be more specific on what files we would want to backup for the configuration? or we could re-engineer the image to pre-populate this etc folder in the case a user maps it locally.